### PR TITLE
Update to add usr/bin/script for Pulsar9

### DIFF
--- a/mk-cube-hello.sh
+++ b/mk-cube-hello.sh
@@ -28,7 +28,7 @@ bins="bin/cat bin/echo bin/cp bin/false bin/ln bin/ls bin/mkdir bin/more bin/mou
 
 # Specific file system additions for enabling of cube-console
 pambins=`ls /lib*/security/*.so /lib*/libnss* |cut -c 2-`
-bins="$bins bin/bash bin/login sbin/agetty usr/bin/socat $pambins"
+bins="$bins bin/bash bin/login sbin/agetty usr/bin/socat usr/bin/script $pambins"
 echo root:x:0:  > etc/group
 echo root:x:0:0:root:/root:/bin/sh > etc/passwd
 echo root::16966:0:99999:7::: > etc/shadow


### PR DESCRIPTION
This is to address the following issue:

root@cube-dom0:~# cube-console cube-hello
exec failed: container_linux.go:265: starting container process caused "exec: \"script\": executable file not found in $PATH"

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>